### PR TITLE
Request to reset effect buffer in clearInputBuffer

### DIFF
--- a/services/audioflinger/Effects.cpp
+++ b/services/audioflinger/Effects.cpp
@@ -2025,6 +2025,10 @@ void AudioFlinger::EffectChain::clearInputBuffer()
         return;
     }
     clearInputBuffer_l(thread);
+
+    for (size_t i = 0; i < mEffects.size(); i++) {
+        mEffects[i]->reset_l();
+    }
 }
 
 // Must be called with EffectChain::mLock locked


### PR DESCRIPTION
When switching track, previous data may remain in work buffer of
effect, and causes pop noise at the begining of next track.
So send reset request to effect during switching track
in order to clear useless data.

Bug: 73720726
Test: No pop noise with AudioEffect when switching track
Change-Id: Iaeb4ab928303310427032617e9398b08f4abe5fa