### PR TITLE
stagefright: Move QCOM_BSP_LEGACY flag to correct blueprint file

### DIFF
--- a/media/libstagefright/bqhelper/Android.bp
+++ b/media/libstagefright/bqhelper/Android.bp
@@ -62,6 +62,14 @@ cc_library_shared {
         "-Wno-documentation",
     ],
 
+    product_variables: {
+        lineage: {
+            uses_qcom_bsp_legacy: {
+                cppflags: ["-DQCOM_BSP_LEGACY"],
+            },
+        },
+    },
+
     sanitize: {
         misc_undefined: [
             "signed-integer-overflow",

--- a/media/libstagefright/omx/Android.bp
+++ b/media/libstagefright/omx/Android.bp
@@ -64,14 +64,6 @@ cc_library_shared {
         "-Wno-documentation",
     ],
 
-    product_variables: {
-        lineage: {
-            uses_qcom_bsp_legacy: {
-                cppflags: ["-DQCOM_BSP_LEGACY"],
-            },
-        },
-    },
-
     sanitize: {
         misc_undefined: [
             "signed-integer-overflow",


### PR DESCRIPTION
In Pie the bufferqueue sources were moved to a new folder.

Change-Id: If56dd48a178658b8b8e261ef0d3851f7fbdc8475